### PR TITLE
Update storage class for RDR CNV workloads

### DIFF
--- a/rdr/cnv-workload/vm-resources/vm-workload-1/vm-1-pvc.yaml
+++ b/rdr/cnv-workload/vm-resources/vm-workload-1/vm-1-pvc.yaml
@@ -13,5 +13,5 @@ spec:
   resources:
     requests:
       storage: 512Mi
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   volumeMode: Block


### PR DESCRIPTION
Use `ocs-storagecluster-ceph-rbd-virtualization` storage class for CNV workloads to prevent CRC errors