### PR TITLE
Source name change to avoid errors while creating workload in existing NS which has another workload

### DIFF
--- a/rdr/cnv-workload/vm-resources/vm-workload-2/vm-1-source.yaml
+++ b/rdr/cnv-workload/vm-resources/vm-workload-2/vm-1-source.yaml
@@ -2,7 +2,7 @@
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: VolumeImportSource
 metadata:
-  name: cirros-source
+  name: cirros-source-2
 spec:
   source:
     registry:


### PR DESCRIPTION
E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /Users/amanagrawal/Downloads/kubeconfig/rdr-419-2/dr-c1/auth/kubeconfig create -k ocs-workloads/rdr/cnv-workload/vm-resources/vm-workload-2 -n cnv-dict-1.
E               Error is # Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
E               Warning: spec.running is deprecated, please use spec.runStrategy instead.
E               Error from server (AlreadyExists): error when creating "ocs-workloads/rdr/cnv-workload/vm-resources/vm-workload-2": volumeimportsources.cdi.kubevirt.io "cirros-source" already exists

ocs_ci/utility/utils.py:732: CommandFailed

for PR https://github.com/red-hat-storage/ocs-ci/pull/12651/