### PR TITLE
Add labels:appname: kubevirt to CNV examples directly

### DIFF
--- a/mdr/cnv-workload/vm-resources/vm-workload-1/kustomization.yaml
+++ b/mdr/cnv-workload/vm-resources/vm-workload-1/kustomization.yaml
@@ -3,7 +3,5 @@ resources:
   - vm-1-source.yaml
   - vm-1-pvc.yaml
   - vm-workload-1.yaml
-commonLabels:
-  appname: kubevirt
 generatorOptions:
   disableNameSuffixHash: true

--- a/mdr/cnv-workload/vm-resources/vm-workload-1/vm-1-pvc.yaml
+++ b/mdr/cnv-workload/vm-resources/vm-workload-1/vm-1-pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vm-1-pvc
+  labels:
+    appname: kubevirt 
 spec:
   dataSourceRef:
     apiGroup: cdi.kubevirt.io

--- a/mdr/cnv-workload/vm-resources/vm-workload-1/vm-workload-1.yaml
+++ b/mdr/cnv-workload/vm-resources/vm-workload-1/vm-workload-1.yaml
@@ -3,6 +3,8 @@ apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: vm-workload-1
+  labels:
+    appname: kubevirt
 spec:
   running: true
   template:
@@ -12,6 +14,7 @@ spec:
         vm.kubevirt.io/os: fedora
         vm.kubevirt.io/workload: server
       labels:
+        appname: kubevirt
         kubevirt.io/size: small
     spec:
       domain:


### PR DESCRIPTION
We are seeing this below error, so directly adding label to VM examples 

```
2026-06-18 16:23:41  E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /home/jenkins/clusters/j-mdr-i1-p136/openshift-cluster-dir/auth/kubeconfig create -k ocs-workloads/mdr/cnv-workload/vm-resources/vm-workload-1 -n dist-wrkld-vm-2f45e2.
2026-06-18 16:23:41  E               Error is # Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
2026-06-18 16:23:41  E               Warning: spec.running is deprecated, please use spec.runStrategy instead.
```