### PR TITLE
Fix release script to handle kustomize images, version-pinned VM tags…

### DIFF
--- a/create_rdr_release.sh
+++ b/create_rdr_release.sh
@@ -191,28 +191,28 @@ run_preflight() {
     done
     if [[ ${#missing_tools[@]} -eq 0 ]]; then
         echo -e "  ${GREEN}[PASS]${NC} Required CLI tools (git, sed, find, grep)"
-        ((pass++))
+        pass=$((pass + 1))
     else
         echo -e "  ${RED}[FAIL]${NC} Required CLI tools — missing: ${missing_tools[*]}"
-        ((fail++))
+        fail=$((fail + 1))
     fi
 
     # 2. Git repository
     if git rev-parse --git-dir &>/dev/null; then
         echo -e "  ${GREEN}[PASS]${NC} Inside a git repository"
-        ((pass++))
+        pass=$((pass + 1))
     else
         echo -e "  ${RED}[FAIL]${NC} Not inside a git repository"
-        ((fail++))
+        fail=$((fail + 1))
     fi
 
     # 3. rdr/ directory exists
     if [[ -d "rdr" ]]; then
         echo -e "  ${GREEN}[PASS]${NC} rdr/ directory exists"
-        ((pass++))
+        pass=$((pass + 1))
     else
         echo -e "  ${RED}[FAIL]${NC} rdr/ directory not found (run from repo root)"
-        ((fail++))
+        fail=$((fail + 1))
     fi
 
     # 4. On master/main branch
@@ -220,19 +220,19 @@ run_preflight() {
     current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
     if [[ "$current_branch" == "master" || "$current_branch" == "main" ]]; then
         echo -e "  ${GREEN}[PASS]${NC} On branch: $current_branch"
-        ((pass++))
+        pass=$((pass + 1))
     else
         echo -e "  ${YELLOW}[WARN]${NC} Not on master/main (current: $current_branch)"
-        ((warn++))
+        warn=$((warn + 1))
     fi
 
     # 5. Remote reachable
     if git ls-remote origin HEAD &>/dev/null; then
         echo -e "  ${GREEN}[PASS]${NC} Remote 'origin' is reachable"
-        ((pass++))
+        pass=$((pass + 1))
     else
         echo -e "  ${RED}[FAIL]${NC} Cannot reach remote 'origin'"
-        ((fail++))
+        fail=$((fail + 1))
     fi
 
     # 6. Branch doesn't already exist (local + remote)
@@ -245,13 +245,13 @@ run_preflight() {
     fi
     if [[ "$branch_exists_local" -eq 0 && "$branch_exists_remote" -eq 0 ]]; then
         echo -e "  ${GREEN}[PASS]${NC} Branch '$branch' does not exist (local or remote)"
-        ((pass++))
+        pass=$((pass + 1))
     else
         local where=""
         [[ "$branch_exists_local" -eq 1 ]] && where="local"
         [[ "$branch_exists_remote" -eq 1 ]] && where="${where:+$where + }remote"
         echo -e "  ${RED}[FAIL]${NC} Branch '$branch' already exists ($where)"
-        ((fail++))
+        fail=$((fail + 1))
     fi
 
     # 7. Container CLI available
@@ -263,10 +263,10 @@ run_preflight() {
     fi
     if [[ -n "$container_cli" ]]; then
         echo -e "  ${GREEN}[PASS]${NC} Container CLI available: $container_cli"
-        ((pass++))
+        pass=$((pass + 1))
     else
         echo -e "  ${YELLOW}[WARN]${NC} No container CLI (podman/docker) found — skipping login check"
-        ((warn++))
+        warn=$((warn + 1))
     fi
 
     # 8. quay.io login
@@ -275,31 +275,31 @@ run_preflight() {
             local user
             user=$($container_cli login --get-login quay.io 2>/dev/null)
             echo -e "  ${GREEN}[PASS]${NC} Logged into quay.io as: $user"
-            ((pass++))
+            pass=$((pass + 1))
         else
             echo -e "  ${RED}[FAIL]${NC} Not logged into quay.io (run: $container_cli login quay.io)"
-            ((fail++))
+            fail=$((fail + 1))
         fi
     else
         echo -e "  ${YELLOW}[WARN]${NC} quay.io login — skipped (no container CLI)"
-        ((warn++))
+        warn=$((warn + 1))
     fi
 
     # 9. skopeo available
     local has_skopeo=0
     if command -v skopeo &>/dev/null; then
         echo -e "  ${GREEN}[PASS]${NC} skopeo is available"
-        ((pass++))
+        pass=$((pass + 1))
         has_skopeo=1
     else
-        echo -e "  ${YELLOW}[WARN]${NC} skopeo not found — skipping image existence checks"
-        ((warn++))
+        echo -e "  ${YELLOW}[WARN]${NC} skopeo not found"
+        warn=$((warn + 1))
     fi
 
-    # 10. Source images exist on quay.io
+    # 10. Verify source images exist on quay.io
     if [[ "$has_skopeo" -eq 1 ]]; then
         echo ""
-        print_info "Verifying source images on quay.io..."
+        print_info "Verifying source images exist on quay.io..."
         local all_images
         all_images=$(
             {
@@ -326,18 +326,21 @@ run_preflight() {
             while IFS= read -r img; do
                 if skopeo inspect "docker://${img}" &>/dev/null; then
                     echo -e "  ${GREEN}[PASS]${NC} Image exists: $img"
-                    ((img_pass++))
+                    img_pass=$((img_pass + 1))
                 else
                     echo -e "  ${RED}[FAIL]${NC} Image NOT found: $img"
-                    ((img_fail++))
+                    img_fail=$((img_fail + 1))
                 fi
             done <<< "$combined"
             pass=$((pass + img_pass))
             fail=$((fail + img_fail))
         else
             echo -e "  ${YELLOW}[WARN]${NC} No images found in rdr/ YAML files"
-            ((warn++))
+            warn=$((warn + 1))
         fi
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} Image existence check — skipped (skopeo not found)"
+        warn=$((warn + 1))
     fi
 
     # Summary
@@ -533,7 +536,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
     updated_count=0
     while IFS= read -r -d '' file; do
         if update_file "$file" "$BRANCH_NAME" "true"; then
-            ((updated_count++))
+            updated_count=$((updated_count + 1))
             echo ""
         fi
     done < <(find rdr -type f \( -name "*.yaml" -o -name "*.yml" \) -print0)
@@ -606,7 +609,7 @@ echo ""
 updated_count=0
 while IFS= read -r -d '' file; do
     if update_file "$file" "$BRANCH_NAME" "false"; then
-        ((updated_count++))
+        updated_count=$((updated_count + 1))
     fi
 done < <(find rdr -type f \( -name "*.yaml" -o -name "*.yml" \) -print0)
 

--- a/create_rdr_release.sh
+++ b/create_rdr_release.sh
@@ -40,12 +40,14 @@ OPTIONS:
     -b, --branch BRANCH_NAME    Release branch name (required)
     -p, --push                  Push changes to remote repository
     -d, --dry-run              Show what would be changed without making changes
+    -c, --check                Run preflight checks only (verify prerequisites)
     -h, --help                 Show this help message
 
 EXAMPLES:
     $0 -b release-4.17
     $0 --branch release-4.17 --push
     $0 -b release-4.17 -d
+    $0 -b release-4.17 -c
 
 DESCRIPTION:
     This script will:
@@ -63,6 +65,7 @@ EOF
 BRANCH_NAME=""
 PUSH_TO_REMOTE=false
 DRY_RUN=false
+PREFLIGHT=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -76,6 +79,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -d|--dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        -c|--check)
+            PREFLIGHT=true
             shift
             ;;
         -h|--help)
@@ -132,6 +139,233 @@ fi
 print_info "Starting RDR release process for branch: $BRANCH_NAME"
 echo ""
 
+# Check quay.io login
+check_quay_login() {
+    local container_cli=""
+    if command -v podman &>/dev/null; then
+        container_cli="podman"
+    elif command -v docker &>/dev/null; then
+        container_cli="docker"
+    else
+        print_warning "Neither podman nor docker found. Cannot verify quay.io login."
+        read -p "Do you want to continue anyway? (y/n): " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_info "Aborted by user."
+            exit 0
+        fi
+        return
+    fi
+
+    print_info "Checking quay.io login using $container_cli..."
+    if $container_cli login --get-login quay.io &>/dev/null; then
+        local user
+        user=$($container_cli login --get-login quay.io 2>/dev/null)
+        print_success "Logged into quay.io as: $user"
+    else
+        print_warning "Not logged into quay.io via $container_cli."
+        print_info "Run '$container_cli login quay.io' to authenticate."
+        read -p "Do you want to continue anyway? (y/n): " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_info "Aborted by user."
+            exit 0
+        fi
+    fi
+}
+
+run_preflight() {
+    local branch=$1
+    local pass=0 fail=0 warn=0
+
+    echo ""
+    print_info "=== Preflight Checks ==="
+    echo ""
+
+    # 1. Required CLI tools
+    local missing_tools=()
+    for tool in git sed find grep; do
+        if ! command -v "$tool" &>/dev/null; then
+            missing_tools+=("$tool")
+        fi
+    done
+    if [[ ${#missing_tools[@]} -eq 0 ]]; then
+        echo -e "  ${GREEN}[PASS]${NC} Required CLI tools (git, sed, find, grep)"
+        ((pass++))
+    else
+        echo -e "  ${RED}[FAIL]${NC} Required CLI tools — missing: ${missing_tools[*]}"
+        ((fail++))
+    fi
+
+    # 2. Git repository
+    if git rev-parse --git-dir &>/dev/null; then
+        echo -e "  ${GREEN}[PASS]${NC} Inside a git repository"
+        ((pass++))
+    else
+        echo -e "  ${RED}[FAIL]${NC} Not inside a git repository"
+        ((fail++))
+    fi
+
+    # 3. rdr/ directory exists
+    if [[ -d "rdr" ]]; then
+        echo -e "  ${GREEN}[PASS]${NC} rdr/ directory exists"
+        ((pass++))
+    else
+        echo -e "  ${RED}[FAIL]${NC} rdr/ directory not found (run from repo root)"
+        ((fail++))
+    fi
+
+    # 4. On master/main branch
+    local current_branch
+    current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    if [[ "$current_branch" == "master" || "$current_branch" == "main" ]]; then
+        echo -e "  ${GREEN}[PASS]${NC} On branch: $current_branch"
+        ((pass++))
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} Not on master/main (current: $current_branch)"
+        ((warn++))
+    fi
+
+    # 5. Remote reachable
+    if git ls-remote origin HEAD &>/dev/null; then
+        echo -e "  ${GREEN}[PASS]${NC} Remote 'origin' is reachable"
+        ((pass++))
+    else
+        echo -e "  ${RED}[FAIL]${NC} Cannot reach remote 'origin'"
+        ((fail++))
+    fi
+
+    # 6. Branch doesn't already exist (local + remote)
+    local branch_exists_local=0 branch_exists_remote=0
+    if git rev-parse --verify "$branch" &>/dev/null; then
+        branch_exists_local=1
+    fi
+    if git ls-remote --heads origin "$branch" 2>/dev/null | grep -q "$branch"; then
+        branch_exists_remote=1
+    fi
+    if [[ "$branch_exists_local" -eq 0 && "$branch_exists_remote" -eq 0 ]]; then
+        echo -e "  ${GREEN}[PASS]${NC} Branch '$branch' does not exist (local or remote)"
+        ((pass++))
+    else
+        local where=""
+        [[ "$branch_exists_local" -eq 1 ]] && where="local"
+        [[ "$branch_exists_remote" -eq 1 ]] && where="${where:+$where + }remote"
+        echo -e "  ${RED}[FAIL]${NC} Branch '$branch' already exists ($where)"
+        ((fail++))
+    fi
+
+    # 7. Container CLI available
+    local container_cli=""
+    if command -v podman &>/dev/null; then
+        container_cli="podman"
+    elif command -v docker &>/dev/null; then
+        container_cli="docker"
+    fi
+    if [[ -n "$container_cli" ]]; then
+        echo -e "  ${GREEN}[PASS]${NC} Container CLI available: $container_cli"
+        ((pass++))
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} No container CLI (podman/docker) found — skipping login check"
+        ((warn++))
+    fi
+
+    # 8. quay.io login
+    if [[ -n "$container_cli" ]]; then
+        if $container_cli login --get-login quay.io &>/dev/null; then
+            local user
+            user=$($container_cli login --get-login quay.io 2>/dev/null)
+            echo -e "  ${GREEN}[PASS]${NC} Logged into quay.io as: $user"
+            ((pass++))
+        else
+            echo -e "  ${RED}[FAIL]${NC} Not logged into quay.io (run: $container_cli login quay.io)"
+            ((fail++))
+        fi
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} quay.io login — skipped (no container CLI)"
+        ((warn++))
+    fi
+
+    # 9. skopeo available
+    local has_skopeo=0
+    if command -v skopeo &>/dev/null; then
+        echo -e "  ${GREEN}[PASS]${NC} skopeo is available"
+        ((pass++))
+        has_skopeo=1
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} skopeo not found — skipping image existence checks"
+        ((warn++))
+    fi
+
+    # 10. Source images exist on quay.io
+    if [[ "$has_skopeo" -eq 1 ]]; then
+        echo ""
+        print_info "Verifying source images on quay.io..."
+        local all_images
+        all_images=$(
+            {
+                grep -rh "image:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null
+                grep -rh "value:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null
+            } | grep -v "quay.io/prometheus" | grep -v "^\s*#" \
+              | sed -E "s/.*(image|value):[[:space:]]*//" \
+              | sed "s/['\"]//g" \
+              | sort -u
+        )
+        local vm_imgs
+        vm_imgs=$(
+            grep -rh "url:.*docker://" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null \
+              | grep -v "^\s*#" \
+              | sed -E "s/.*url:[[:space:]]*//" \
+              | sed "s/['\"]//g" | sed "s|docker://||" \
+              | sort -u
+        )
+        local combined
+        combined=$(echo -e "${all_images}\n${vm_imgs}" | grep -v "^$" | sort -u)
+
+        if [[ -n "$combined" ]]; then
+            local img_pass=0 img_fail=0
+            while IFS= read -r img; do
+                if skopeo inspect "docker://${img}" &>/dev/null; then
+                    echo -e "  ${GREEN}[PASS]${NC} Image exists: $img"
+                    ((img_pass++))
+                else
+                    echo -e "  ${RED}[FAIL]${NC} Image NOT found: $img"
+                    ((img_fail++))
+                fi
+            done <<< "$combined"
+            pass=$((pass + img_pass))
+            fail=$((fail + img_fail))
+        else
+            echo -e "  ${YELLOW}[WARN]${NC} No images found in rdr/ YAML files"
+            ((warn++))
+        fi
+    fi
+
+    # Summary
+    echo ""
+    print_info "=== Preflight Summary ==="
+    echo -e "  ${GREEN}PASS: $pass${NC}  ${RED}FAIL: $fail${NC}  ${YELLOW}WARN: $warn${NC}"
+    echo ""
+
+    if [[ "$fail" -gt 0 ]]; then
+        print_error "Preflight checks failed. Fix the issues above before running the release."
+        return 1
+    else
+        print_success "All preflight checks passed!"
+        return 0
+    fi
+}
+
+# Run preflight checks if requested
+if [[ "$PREFLIGHT" == "true" ]]; then
+    run_preflight "$BRANCH_NAME"
+    exit $?
+fi
+
+if [[ "$DRY_RUN" == "false" ]]; then
+    check_quay_login
+    echo ""
+fi
+
 # Check for uncommitted changes
 if [[ -n $(git status -s) ]]; then
     print_warning "You have uncommitted changes:"
@@ -181,9 +415,9 @@ update_file() {
         has_github_url=1
     fi
 
-    # Check for VM containerDisk images (url: docker://) with :latest tag only - excluding prometheus
+    # Check for VM containerDisk images (url: docker://)
     local has_vm_images=0
-    if grep "url:.*docker://.*:latest" "$file" 2>/dev/null | grep -qv "quay.io/prometheus"; then
+    if grep -q "url:.*docker://" "$file" 2>/dev/null; then
         has_vm_images=1
     fi
 
@@ -254,10 +488,10 @@ update_file() {
             done
         fi
 
-        # Show VM containerDisk image changes (only :latest, excluding prometheus)
+        # Show VM containerDisk image changes (excluding prometheus)
         if [[ "$has_vm_images" -eq 1 ]]; then
             echo "  VM Images (containerDisk):"
-            grep "url:.*docker://.*:latest" "$file" | grep -v "quay.io/prometheus" | while read -r line; do
+            grep "url:.*docker://" "$file" | while read -r line; do
                 local old_url=$(echo "$line" | sed 's/.*url:[[:space:]]*//g' | sed "s/'//g" | sed 's/"//g')
                 local new_url=$(echo "$old_url" | sed "s/\(.*\):[^:]*$/\1:${branch}/")
                 echo "    OLD: $old_url"
@@ -273,7 +507,7 @@ update_file() {
             [[ "$has_target_revision" -eq 1 ]] && sed -i '' "s/targetRevision: master/targetRevision: ${branch}/g" "$file"
             [[ "$has_git_branch" -eq 1 ]] && sed -i '' "s/\(git-branch: \)master/\1${branch}/g; s/\(github-branch: \)master/\1${branch}/g" "$file"
             [[ "$has_github_url" -eq 1 ]] && sed -i '' "s|raw.githubusercontent.com/red-hat-storage/ocs-workloads/master|raw.githubusercontent.com/red-hat-storage/ocs-workloads/${branch}|g" "$file"
-            [[ "$has_vm_images" -eq 1 ]] && sed -i '' "/quay.io\/prometheus/!s|\(url:.*docker://[^:]*\):latest|\1:${branch}|g" "$file"
+            [[ "$has_vm_images" -eq 1 ]] && sed -i '' "s|\(url:.*docker://[^:]*\):[^'\"[:space:]]*|\1:${branch}|g" "$file"
         else
             # Linux sed doesn't need '' after -i
             [[ "$has_image_tags" -eq 1 ]] && sed -i "/quay.io\/prometheus/!s/:latest/:${branch}/g" "$file"
@@ -281,7 +515,7 @@ update_file() {
             [[ "$has_target_revision" -eq 1 ]] && sed -i "s/targetRevision: master/targetRevision: ${branch}/g" "$file"
             [[ "$has_git_branch" -eq 1 ]] && sed -i "s/\(git-branch: \)master/\1${branch}/g; s/\(github-branch: \)master/\1${branch}/g" "$file"
             [[ "$has_github_url" -eq 1 ]] && sed -i "s|raw.githubusercontent.com/red-hat-storage/ocs-workloads/master|raw.githubusercontent.com/red-hat-storage/ocs-workloads/${branch}|g" "$file"
-            [[ "$has_vm_images" -eq 1 ]] && sed -i "/quay.io\/prometheus/!s|\(url:.*docker://[^:]*\):latest|\1:${branch}|g" "$file"
+            [[ "$has_vm_images" -eq 1 ]] && sed -i "s|\(url:.*docker://[^:]*\):[^'\"[:space:]]*|\1:${branch}|g" "$file"
         fi
         print_success "Updated: $file"
     fi
@@ -303,6 +537,43 @@ if [[ "$DRY_RUN" == "true" ]]; then
             echo ""
         fi
     done < <(find rdr -type f \( -name "*.yaml" -o -name "*.yml" \) -print0)
+
+    # Image update summary
+    echo ""
+    print_info "=== Image Update Summary ==="
+    echo ""
+
+    print_success "Images that WILL be retagged to :${BRANCH_NAME}:"
+    updated_images=$(
+        {
+            grep -rh "image:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null
+            grep -rh "value:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null
+        } | grep -v "quay.io/prometheus" | grep -v "^\s*#" \
+          | sed -E "s/.*(image|value):[[:space:]]*//" \
+          | sed "s/['\"]//g" \
+          | sort -u
+    )
+    vm_images=$(
+        grep -rh "url:.*docker://" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null \
+          | grep -v "^\s*#" \
+          | sed -E "s/.*url:[[:space:]]*//" \
+          | sed "s/['\"]//g" | sed "s|docker://||" \
+          | sort -u
+    )
+    if [[ -n "$updated_images" ]]; then
+        echo "$updated_images" | while read -r img; do
+            echo "    ${img} → ${img/:latest/:${BRANCH_NAME}}"
+        done
+    fi
+    if [[ -n "$vm_images" ]]; then
+        echo "$vm_images" | while read -r img; do
+            new_img=$(echo "$img" | sed "s/\(.*\):[^:]*$/\1:${BRANCH_NAME}/")
+            echo "    ${img} → ${new_img}"
+        done
+    fi
+    if [[ -z "$updated_images" && -z "$vm_images" ]]; then
+        echo "    (none)"
+    fi
 
     echo ""
     print_info "Total files that would be updated: $updated_count"

--- a/create_rdr_release.sh
+++ b/create_rdr_release.sh
@@ -157,6 +157,12 @@ update_file() {
         has_image_tags=1
     fi
 
+    # Check for kustomize patch value: image references (excluding prometheus)
+    local has_kustomize_images=0
+    if grep "value:.*:latest" "$file" 2>/dev/null | grep -qv "quay.io/prometheus"; then
+        has_kustomize_images=1
+    fi
+
     # Check for targetRevision: master
     local has_target_revision=0
     if grep -q "targetRevision: master" "$file" 2>/dev/null; then
@@ -175,14 +181,26 @@ update_file() {
         has_github_url=1
     fi
 
-    # Check for VM containerDisk images (url: docker://) - excluding prometheus
+    # Check for VM containerDisk images (url: docker://) with :latest tag only - excluding prometheus
     local has_vm_images=0
-    if grep "url:.*docker://" "$file" 2>/dev/null | grep -qv "quay.io/prometheus"; then
+    if grep "url:.*docker://.*:latest" "$file" 2>/dev/null | grep -qv "quay.io/prometheus"; then
         has_vm_images=1
     fi
 
+    # Warn about non-master branch references in git-branch/github-branch annotations
+    if grep -q -E "git-branch:|github-branch:" "$file" 2>/dev/null; then
+        local non_master_branches
+        non_master_branches=$(grep -E "git-branch:|github-branch:" "$file" | grep -v "master" | grep -v "^\s*#")
+        if [[ -n "$non_master_branches" ]]; then
+            print_warning "Skipping non-master branch reference in $file:"
+            echo "$non_master_branches" | while read -r line; do
+                echo "    $line"
+            done
+        fi
+    fi
+
     # Skip if no changes needed
-    if [[ "$has_image_tags" -eq 0 && "$has_target_revision" -eq 0 && "$has_git_branch" -eq 0 && "$has_github_url" -eq 0 && "$has_vm_images" -eq 0 ]]; then
+    if [[ "$has_image_tags" -eq 0 && "$has_kustomize_images" -eq 0 && "$has_target_revision" -eq 0 && "$has_git_branch" -eq 0 && "$has_github_url" -eq 0 && "$has_vm_images" -eq 0 ]]; then
         return 1
     fi
 
@@ -227,11 +245,19 @@ update_file() {
             done
         fi
 
-        # Show VM containerDisk image changes (excluding prometheus)
+        # Show kustomize patch value: image changes (excluding prometheus)
+        if [[ "$has_kustomize_images" -eq 1 ]]; then
+            echo "  Kustomize patch images:"
+            grep "value:.*:latest" "$file" | grep -v "quay.io/prometheus" | while read -r line; do
+                echo "    OLD: $line"
+                echo "    NEW: ${line/:latest/:${branch}}"
+            done
+        fi
+
+        # Show VM containerDisk image changes (only :latest, excluding prometheus)
         if [[ "$has_vm_images" -eq 1 ]]; then
             echo "  VM Images (containerDisk):"
-            grep "url:.*docker://" "$file" | grep -v "quay.io/prometheus" | while read -r line; do
-                # Extract just the image part for display
+            grep "url:.*docker://.*:latest" "$file" | grep -v "quay.io/prometheus" | while read -r line; do
                 local old_url=$(echo "$line" | sed 's/.*url:[[:space:]]*//g' | sed "s/'//g" | sed 's/"//g')
                 local new_url=$(echo "$old_url" | sed "s/\(.*\):[^:]*$/\1:${branch}/")
                 echo "    OLD: $old_url"
@@ -242,22 +268,20 @@ update_file() {
         # Apply changes based on OS
         if [[ "$OSTYPE" == "darwin"* ]]; then
             # macOS sed requires '' after -i
-            # For image tags: exclude prometheus images from replacement
             [[ "$has_image_tags" -eq 1 ]] && sed -i '' "/quay.io\/prometheus/!s/:latest/:${branch}/g" "$file"
+            [[ "$has_kustomize_images" -eq 1 ]] && sed -i '' "/quay.io\/prometheus/!s/:latest/:${branch}/g" "$file"
             [[ "$has_target_revision" -eq 1 ]] && sed -i '' "s/targetRevision: master/targetRevision: ${branch}/g" "$file"
             [[ "$has_git_branch" -eq 1 ]] && sed -i '' "s/\(git-branch: \)master/\1${branch}/g; s/\(github-branch: \)master/\1${branch}/g" "$file"
             [[ "$has_github_url" -eq 1 ]] && sed -i '' "s|raw.githubusercontent.com/red-hat-storage/ocs-workloads/master|raw.githubusercontent.com/red-hat-storage/ocs-workloads/${branch}|g" "$file"
-            # For VM images: exclude prometheus images from replacement
-            [[ "$has_vm_images" -eq 1 ]] && sed -i '' "/quay.io\/prometheus/!s|\(url:.*docker://[^:]*\):[^\"']*|\1:${branch}|g" "$file"
+            [[ "$has_vm_images" -eq 1 ]] && sed -i '' "/quay.io\/prometheus/!s|\(url:.*docker://[^:]*\):latest|\1:${branch}|g" "$file"
         else
             # Linux sed doesn't need '' after -i
-            # For image tags: exclude prometheus images from replacement
             [[ "$has_image_tags" -eq 1 ]] && sed -i "/quay.io\/prometheus/!s/:latest/:${branch}/g" "$file"
+            [[ "$has_kustomize_images" -eq 1 ]] && sed -i "/quay.io\/prometheus/!s/:latest/:${branch}/g" "$file"
             [[ "$has_target_revision" -eq 1 ]] && sed -i "s/targetRevision: master/targetRevision: ${branch}/g" "$file"
             [[ "$has_git_branch" -eq 1 ]] && sed -i "s/\(git-branch: \)master/\1${branch}/g; s/\(github-branch: \)master/\1${branch}/g" "$file"
             [[ "$has_github_url" -eq 1 ]] && sed -i "s|raw.githubusercontent.com/red-hat-storage/ocs-workloads/master|raw.githubusercontent.com/red-hat-storage/ocs-workloads/${branch}|g" "$file"
-            # For VM images: exclude prometheus images from replacement
-            [[ "$has_vm_images" -eq 1 ]] && sed -i "/quay.io\/prometheus/!s|\(url:.*docker://[^:]*\):[^\"']*|\1:${branch}|g" "$file"
+            [[ "$has_vm_images" -eq 1 ]] && sed -i "/quay.io\/prometheus/!s|\(url:.*docker://[^:]*\):latest|\1:${branch}|g" "$file"
         fi
         print_success "Updated: $file"
     fi

--- a/tag_images.sh
+++ b/tag_images.sh
@@ -284,6 +284,8 @@ fi
 success_count=0
 failed_count=0
 declare -a failed_images
+declare -a tagged_report
+declare -a not_tagged_report
 
 for ((i=0; i<${#image_names[@]}; i++)); do
     image="${image_names[$i]}"
@@ -294,6 +296,7 @@ for ((i=0; i<${#image_names[@]}; i++)); do
         echo "  Would tag: ${image}:${current_tag} → ${image}:${RELEASE_TAG}"
         echo "  Would push: ${image}:${RELEASE_TAG}"
         success_count=$((success_count + 1))
+        tagged_report+=("${image}:${current_tag}|${image}:${RELEASE_TAG}|DRY-RUN")
     else
         case "$METHOD" in
             skopeo)
@@ -314,10 +317,12 @@ for ((i=0; i<${#image_names[@]}; i++)); do
                     docker://${image}:${RELEASE_TAG} 2>&1; then
                     print_success "Tagged and pushed: ${image}:${RELEASE_TAG}"
                     success_count=$((success_count + 1))
+                    tagged_report+=("${image}:${current_tag}|${image}:${RELEASE_TAG}|TAGGED")
                 else
                     print_error "Failed to tag: ${image}"
                     failed_images+=("$image")
                     failed_count=$((failed_count + 1))
+                    not_tagged_report+=("${image}:${current_tag}|${image}:${RELEASE_TAG}|FAILED")
                 fi
                 ;;
             docker|podman)
@@ -329,10 +334,12 @@ for ((i=0; i<${#image_names[@]}; i++)); do
                    ${METHOD} push ${image}:${RELEASE_TAG}; then
                     print_success "Tagged and pushed: ${image}:${RELEASE_TAG}"
                     success_count=$((success_count + 1))
+                    tagged_report+=("${image}:${current_tag}|${image}:${RELEASE_TAG}|TAGGED")
                 else
                     print_error "Failed to tag: ${image}"
                     failed_images+=("$image")
                     failed_count=$((failed_count + 1))
+                    not_tagged_report+=("${image}:${current_tag}|${image}:${RELEASE_TAG}|FAILED")
                 fi
                 ;;
         esac
@@ -343,11 +350,30 @@ done
 # Print summary
 echo ""
 echo "=========================================="
-print_info "Summary"
+print_info "Release Tagging Report"
 echo "=========================================="
-echo "Total images: $total_images"
-echo "Successfully tagged: $success_count"
-echo "Failed: $failed_count"
+echo ""
+printf "  %-55s %-15s %s\n" "SOURCE" "TARGET TAG" "STATUS"
+printf "  %-55s %-15s %s\n" "------" "----------" "------"
+
+if [[ ${#tagged_report[@]} -gt 0 ]]; then
+    for entry in "${tagged_report[@]}"; do
+        IFS='|' read -r src dst status <<< "$entry"
+        target_tag=$(echo "$dst" | sed 's/.*://')
+        printf "  ${GREEN}%-55s %-15s %s${NC}\n" "$src" ":$target_tag" "$status"
+    done
+fi
+
+if [[ ${#not_tagged_report[@]} -gt 0 ]]; then
+    for entry in "${not_tagged_report[@]}"; do
+        IFS='|' read -r src dst status <<< "$entry"
+        target_tag=$(echo "$dst" | sed 's/.*://')
+        printf "  ${RED}%-55s %-15s %s${NC}\n" "$src" ":$target_tag" "$status"
+    done
+fi
+
+echo ""
+echo "  Total: $total_images | Tagged: $success_count | Failed: $failed_count"
 echo ""
 
 if [[ $failed_count -gt 0 ]]; then
@@ -366,8 +392,8 @@ else
     print_success "All images tagged and pushed successfully!"
     echo ""
     print_info "Next steps:"
-    echo "  1. Verify images in Quay.io web interface"
-    echo "  2. Run: ./create_rdr_release.sh -b $RELEASE_TAG"
+    echo "  1. Verify images: ./verify_images.sh -t $RELEASE_TAG"
+    echo "  2. Create release: ./create_rdr_release.sh -b $RELEASE_TAG"
 fi
 
 echo ""

--- a/tag_images.sh
+++ b/tag_images.sh
@@ -210,9 +210,12 @@ declare -a image_current_tags
 temp_file=$(mktemp)
 trap 'rm -f "$temp_file"' EXIT
 
-# Pattern 1: Extract images with :latest tag (container images)
-grep -rh "image:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null | \
-    sed 's/.*image:[[:space:]]*//g' | \
+# Pattern 1: Extract images with :latest tag (container images + kustomize patches)
+{
+    grep -rh "image:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null
+    grep -rh "value:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null
+} | \
+    sed -E 's/.*(image|value):[[:space:]]*//g' | \
     sed 's/[[:space:]]*#.*//g' | \
     sed "s/'//g" | \
     sed 's/"//g' | \
@@ -228,7 +231,6 @@ done
 
 # Pattern 2: Extract VM images with any tag (containerDisk images)
 grep -rh "url:.*docker://" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null | \
-    grep -v "quay.io/prometheus" | \
     sort -u | \
 while IFS= read -r line; do
     if [[ -n "$line" ]]; then
@@ -291,7 +293,7 @@ for ((i=0; i<${#image_names[@]}; i++)); do
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "  Would tag: ${image}:${current_tag} → ${image}:${RELEASE_TAG}"
         echo "  Would push: ${image}:${RELEASE_TAG}"
-        ((success_count++))
+        success_count=$((success_count + 1))
     else
         case "$METHOD" in
             skopeo)
@@ -311,11 +313,11 @@ for ((i=0; i<${#image_names[@]}; i++)); do
                     docker://${image}:${current_tag} \
                     docker://${image}:${RELEASE_TAG} 2>&1; then
                     print_success "Tagged and pushed: ${image}:${RELEASE_TAG}"
-                    ((success_count++))
+                    success_count=$((success_count + 1))
                 else
                     print_error "Failed to tag: ${image}"
                     failed_images+=("$image")
-                    ((failed_count++))
+                    failed_count=$((failed_count + 1))
                 fi
                 ;;
             docker|podman)
@@ -326,11 +328,11 @@ for ((i=0; i<${#image_names[@]}; i++)); do
                    ${METHOD} tag ${image}:${current_tag} ${image}:${RELEASE_TAG} && \
                    ${METHOD} push ${image}:${RELEASE_TAG}; then
                     print_success "Tagged and pushed: ${image}:${RELEASE_TAG}"
-                    ((success_count++))
+                    success_count=$((success_count + 1))
                 else
                     print_error "Failed to tag: ${image}"
                     failed_images+=("$image")
-                    ((failed_count++))
+                    failed_count=$((failed_count + 1))
                 fi
                 ;;
         esac

--- a/verify_images.sh
+++ b/verify_images.sh
@@ -174,7 +174,12 @@ done < <(
         sed 's/.*image:[[:space:]]*//g' | \
         sed 's/:latest//g'
 
-        # Pattern 2: url: docker:// with any tag (for VM images)
+        # Pattern 2: kustomize value: with :latest tag
+        grep -rh "value:.*:latest" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null | \
+        sed 's/.*value:[[:space:]]*//g' | \
+        sed 's/:latest//g'
+
+        # Pattern 3: url: docker:// with any tag (for VM images)
         grep -rh "url:.*docker://" rdr/ --include="*.yaml" --include="*.yml" 2>/dev/null | \
         sed 's/.*docker:\/\///g' | \
         sed 's/\(.*\):[^:]*$/\1/'  # Remove tag
@@ -209,11 +214,11 @@ for image in "${images[@]}"; do
 
     if skopeo inspect $SKOPEO_OPTS docker://${full_image} &> /dev/null; then
         print_success "$full_image"
-        ((success_count++))
+        success_count=$((success_count + 1))
     else
         print_error "$full_image (NOT FOUND)"
         missing_images+=("$full_image")
-        ((failed_count++))
+        failed_count=$((failed_count + 1))
 
         # Collect debug information if debug mode is enabled
         if [[ "$DEBUG" == "true" ]]; then

--- a/verify_images.sh
+++ b/verify_images.sh
@@ -208,6 +208,8 @@ success_count=0
 failed_count=0
 declare -a missing_images
 declare -a missing_details
+declare -a verified_report
+declare -a not_verified_report
 
 for image in "${images[@]}"; do
     full_image="${image}:${RELEASE_TAG}"
@@ -215,10 +217,12 @@ for image in "${images[@]}"; do
     if skopeo inspect $SKOPEO_OPTS docker://${full_image} &> /dev/null; then
         print_success "$full_image"
         success_count=$((success_count + 1))
+        verified_report+=("${full_image}|FOUND")
     else
         print_error "$full_image (NOT FOUND)"
         missing_images+=("$full_image")
         failed_count=$((failed_count + 1))
+        not_verified_report+=("${full_image}|NOT FOUND")
 
         # Collect debug information if debug mode is enabled
         if [[ "$DEBUG" == "true" ]]; then
@@ -247,11 +251,28 @@ done
 # Print summary
 echo ""
 echo "=========================================="
-print_info "Verification Summary"
+print_info "Verification Report"
 echo "=========================================="
-echo "Total images checked: $total_images"
-echo "Found: $success_count"
-echo "Missing: $failed_count"
+echo ""
+printf "  %-55s %s\n" "IMAGE" "STATUS"
+printf "  %-55s %s\n" "-----" "------"
+
+if [[ ${#verified_report[@]} -gt 0 ]]; then
+    for entry in "${verified_report[@]}"; do
+        IFS='|' read -r img status <<< "$entry"
+        printf "  ${GREEN}%-55s %s${NC}\n" "$img" "$status"
+    done
+fi
+
+if [[ ${#not_verified_report[@]} -gt 0 ]]; then
+    for entry in "${not_verified_report[@]}"; do
+        IFS='|' read -r img status <<< "$entry"
+        printf "  ${RED}%-55s %s${NC}\n" "$img" "$status"
+    done
+fi
+
+echo ""
+echo "  Total: $total_images | Found: $success_count | Missing: $failed_count"
 echo ""
 
 if [[ $failed_count -gt 0 ]]; then


### PR DESCRIPTION
…, and non-master branches

- Add detection for kustomize patch value: image references (busybox-3/4/5) that were silently missed because they use value: instead of image:
- Restrict VM containerDisk replacement to :latest tags only, preventing version-pinned images like cirros-dd:0.6.3 from being incorrectly retagged
- Add warning when git-branch/github-branch annotations reference a non-master branch (e.g. less_workload_rbd) so users know a file was skipped